### PR TITLE
Fix typos

### DIFF
--- a/LICENSE.adoc
+++ b/LICENSE.adoc
@@ -68,9 +68,9 @@ Article 43 of the Rules shall make available to the public in a timely
 manner all documents concerning the arbitration which are communicated
 to it, including all submissions of the parties, all evidence admitted
 into the record of the proceedings, all transcripts or other recordings
-of hearings and all orders, decisions and awards of the arbitral
-tribunal, subject only to the arbitral tribunal’s powers to take such
-measures as may be necessary to safeguard the integrity of the arbitral
+of hearings and all orders, decisions and awards of the arbitrary
+tribunal, subject only to the arbitrary tribunal’s powers to take such
+measures as may be necessary to safeguard the integrity of the arbitrary
 process pursuant to Articles 18, 33, 41 and 42 of the Rules; and (3)
 Article 26(6) of the Rules shall not apply.
 . Human Rights Laws. The Software shall not be used by any person or

--- a/VERSIONS.adoc
+++ b/VERSIONS.adoc
@@ -127,7 +127,7 @@
 * Updated graph node to answer itself - Brooke Kuhlmann
 * Updated to Caliber 0.35.0 - Brooke Kuhlmann
 * Updated to Git Lint 6.0.0 - Brooke Kuhlmann
-* Refactored action and command inherted callback terminology - Brooke Kuhlmann
+* Refactored action and command inherited callback terminology - Brooke Kuhlmann
 * Refactored context override terminology - Brooke Kuhlmann
 
 == 0.0.0 (2023-06-15)

--- a/spec/lib/sod/action_spec.rb
+++ b/spec/lib/sod/action_spec.rb
@@ -64,7 +64,7 @@ RSpec.describe Sod::Action do
       expect(action.new.ancillary).to eq(["One."])
     end
 
-    it "answers emtpy array when undefined" do
+    it "answers empty array when undefined" do
       expect(action.ancillary).to eq([])
     end
 

--- a/spec/lib/sod/command_spec.rb
+++ b/spec/lib/sod/command_spec.rb
@@ -90,7 +90,7 @@ RSpec.describe Sod::Command do
       expect(command.new.ancillary).to eq(["One."])
     end
 
-    it "answers emtpy array when undefined" do
+    it "answers empty array when undefined" do
       expect(command.ancillary).to eq([])
     end
 


### PR DESCRIPTION
## Overview
Fix typos found via `codespell -H`

## Screenshots/Screencasts
<!-- Optional. Provide supporting image/video. -->

## Details
<!-- Optional. List the key features/highlights as bullet points. -->
